### PR TITLE
Rework for glutin `0.30`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Unreleased (v0.30.0)
+* Reworked API to support _glutin_ `0.30`. See new docs & examples.
+* Crate version will no longer follow _glutin_ as now _winit_ releases may separately cause breaking changes.
+
+# v0.29.2
+* Fix docs.rs build.
+
+# v0.29.1
+* Remove all feature requirements from _glutin_ to allow disabling _glutin_ features.
+
+# v0.29.0
+* Update _glutin_ to `0.29`.
+
+# v0.28.0
+* Update _glutin_ to `0.28`.
+
+# v0.27.0
+* Update _glutin_ to `0.27`.
+
+# v0.26.0
+* Update _glutin_ to `0.26`.
+
+# v0.25.0
+* Update _glutin_ to `0.25`.
+
+# v0.24.0
+* Update _glutin_ to `0.24`.
+
+# v0.23.0
+* Update _glutin_ to `0.23`.
+
+# v0.22.1
+* Add `ContextBuilderExt::with_gfx_color_raw`, `ContextBuilderExt::with_gfx_depth_raw` methods.
+
+# v0.22.0
+Initial release supporting _glutin_ `0.22`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,10 @@ glutin-winit = { version = "0.2.1", default-features = false }
 raw-window-handle = "0.5"
 winit = { version = "0.27", default-features = false }
 
-[package.metadata.docs.rs]
-features = ["glutin-winit/default"]
-
 [dev-dependencies]
 gfx = "0.18"
 # enable default features for examples
 winit = { version = "0.27", default-features = true }
-glutin-winit = { version = "0.2.1", default-features = true }
+
+[features]
+default = ["glutin-winit/default"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "old_school_gfx_glutin_ext"
-version = "0.29.2"
+version = "0.30.0-beta.0"
 authors = ["Alex Butler <alexheretic@gmail.com>"]
 edition = "2021"
 description = "Extensions for glutin to initialize & update old school gfx"
@@ -18,10 +18,10 @@ raw-window-handle = "0.5"
 winit = { version = "0.27", default-features = false }
 
 [package.metadata.docs.rs]
-features = ["glutin/x11"]
+features = ["glutin-winit/default"]
 
 [dev-dependencies]
 gfx = "0.18"
 # enable default features for examples
-winit = "0.27"
-glutin-winit = "0.2.1"
+winit = { version = "0.27", default-features = true }
+glutin-winit = { version = "0.2.1", default-features = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "old_school_gfx_glutin_ext"
-# Version should be inline with glutin target version
 version = "0.29.2"
 authors = ["Alex Butler <alexheretic@gmail.com>"]
 edition = "2021"
@@ -11,13 +10,18 @@ license = "Apache-2.0"
 readme="README.md"
 
 [dependencies]
-glutin = { version = "0.29", default-features = false }
 gfx_core = "0.9.2"
 gfx_device_gl = "0.16.2"
+glutin = { version = "0.30.3", default-features = false }
+glutin-winit = { version = "0.2.1", default-features = false }
+raw-window-handle = "0.5"
+winit = { version = "0.27", default-features = false }
 
 [package.metadata.docs.rs]
 features = ["glutin/x11"]
 
 [dev-dependencies]
 gfx = "0.18"
-glutin = "0.29" # use default-features
+# enable default features for examples
+winit = "0.27"
+glutin-winit = "0.2.1"

--- a/README.md
+++ b/README.md
@@ -3,24 +3,34 @@ old_school_gfx_glutin_ext
 [![Documentation](https://docs.rs/old_school_gfx_glutin_ext/badge.svg)](https://docs.rs/old_school_gfx_glutin_ext)
 =========================
 
-Extensions for [glutin](https://crates.io/crates/glutin) to initialize & update old school
-[gfx](https://crates.io/crates/gfx). _An alternative to gfx_window_glutin_.
+Initialise & update old school [gfx](https://crates.io/crates/gfx) with [glutin](https://crates.io/crates/glutin) + [winit](https://crates.io/crates/winit).
 
 ```rust
-use old_school_gfx_glutin_ext::*;
-
 type ColorFormat = gfx::format::Srgba8;
 type DepthFormat = gfx::format::DepthStencil;
 
-// Initialize
-let (window_ctx, mut device, mut factory, mut main_color, mut main_depth) =
-    glutin::ContextBuilder::new()
-        .with_gfx_color_depth::<ColorFormat, DepthFormat>()
-        .build_windowed(window_config, &event_loop)?
-        .init_gfx::<ColorFormat, DepthFormat>();
+let event_loop = winit::event_loop::EventLoop::new();
+let window_builder = winit::window::WindowBuilder::new();
 
-// Update, ie after a resize
-window_ctx.update_gfx(&mut main_color, &mut main_depth);
+// Initialise winit window, glutin context & gfx views
+let old_school_gfx_glutin_ext::Init {
+    // winit window
+    window,
+    // glutin bits
+    gl_config,
+    gl_surface,
+    gl_context,
+    // gfx bits
+    mut device,
+    mut factory,
+    mut color_view,
+    mut depth_view,
+    ..
+} = old_school_gfx_glutin_ext::window_builder(&event_loop, window_builder)
+    .build::<ColorFormat, DepthFormat>()?;
+
+// Update gfx views, e.g. after a window resize
+old_school_gfx_glutin_ext::resize_views(new_size, &mut color_view, &mut depth_view);
 ```
 
 ## Example

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -62,11 +62,12 @@ pub fn main() -> Result<(), Box<dyn Error>> {
         mut depth_view,
         ..
     } = old_school_gfx_glutin_ext::window_builder(
+        &events,
         WindowBuilder::new()
             .with_title("Triangle")
             .with_inner_size(winit::dpi::PhysicalSize::new(1024, 768)),
     )
-    .build::<ColorFormat, DepthFormat>(&events)?;
+    .build::<ColorFormat, DepthFormat>()?;
 
     let mut encoder = gfx::Encoder::from(factory.create_command_buffer());
 

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -1,17 +1,19 @@
 //! Usage example of drawing a triangle.
 //!
-//! This library is the `with_gfx_color_depth`, `init_gfx`, `update_gfx` bits.
+//! Look for `old_school_gfx_glutin_ext` to see what this crate is doing:
+//! * Initialise window & gfx.
+//! * Resize gfx views.
 #[macro_use]
 extern crate gfx;
 
 use gfx::{traits::FactoryExt, Device};
-use glutin::{
+use glutin::surface::GlSurface;
+use std::{error::Error, num::NonZeroU32};
+use winit::{
     event::{Event, KeyboardInput, VirtualKeyCode, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     window::WindowBuilder,
 };
-use old_school_gfx_glutin_ext::*;
-use std::error::Error;
 
 type ColorFormat = gfx::format::Srgba8;
 type DepthFormat = gfx::format::DepthStencil;
@@ -47,17 +49,24 @@ const TRIANGLE: [Vertex; 3] = [
 const CLEAR_COLOR: [f32; 4] = [0.1, 0.11, 0.12, 1.0];
 
 pub fn main() -> Result<(), Box<dyn Error>> {
-    let event_loop = EventLoop::new();
-    let window_config = WindowBuilder::new()
-        .with_title("Triangle".to_string())
-        .with_inner_size(glutin::dpi::PhysicalSize::new(1024, 768));
+    let events = EventLoop::new();
 
-    // vvvvvvvvvvv      Initialize gfx      vvvvvvvvvvv
-    let (window_ctx, mut device, mut factory, main_color, mut main_depth) =
-        glutin::ContextBuilder::new()
-            .with_gfx_color_depth::<ColorFormat, DepthFormat>()
-            .build_windowed(window_config, &event_loop)?
-            .init_gfx::<ColorFormat, DepthFormat>();
+    // Initialise winit window, glutin context & gfx views
+    let old_school_gfx_glutin_ext::Init {
+        window,
+        gl_surface,
+        gl_context,
+        mut device,
+        mut factory,
+        color_view,
+        mut depth_view,
+        ..
+    } = old_school_gfx_glutin_ext::window_builder(
+        WindowBuilder::new()
+            .with_title("Triangle")
+            .with_inner_size(winit::dpi::PhysicalSize::new(1024, 768)),
+    )
+    .build::<ColorFormat, DepthFormat>(&events)?;
 
     let mut encoder = gfx::Encoder::from(factory.create_command_buffer());
 
@@ -70,20 +79,16 @@ pub fn main() -> Result<(), Box<dyn Error>> {
     let (vertex_buffer, slice) = factory.create_vertex_buffer_with_slice(&TRIANGLE, ());
     let mut data = pipe::Data {
         vbuf: vertex_buffer,
-        out: main_color,
+        out: color_view,
     };
+    let mut dimensions = window.inner_size();
 
-    event_loop.run(move |event, _, control_flow| {
+    events.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Poll;
 
         match event {
-            Event::MainEventsCleared => window_ctx.window().request_redraw(),
+            Event::MainEventsCleared => window.request_redraw(),
             Event::WindowEvent { event, .. } => match event {
-                WindowEvent::Resized(physical) => {
-                    window_ctx.resize(physical);
-                    // vvvvvvvvvvv    Update gfx views      vvvvvvvvvvv
-                    window_ctx.update_gfx(&mut data.out, &mut main_depth);
-                }
                 WindowEvent::CloseRequested
                 | WindowEvent::KeyboardInput {
                     input:
@@ -96,11 +101,28 @@ pub fn main() -> Result<(), Box<dyn Error>> {
                 _ => (),
             },
             Event::RedrawRequested(_) => {
+                // handle resizes
+                let window_size = window.inner_size();
+                if dimensions != window_size {
+                    if let (Some(w), Some(h)) = (
+                        NonZeroU32::new(window_size.width),
+                        NonZeroU32::new(window_size.height),
+                    ) {
+                        gl_surface.resize(&gl_context, w, h);
+                        old_school_gfx_glutin_ext::resize_views(
+                            window_size,
+                            &mut data.out,
+                            &mut depth_view,
+                        );
+                    }
+                    dimensions = window_size;
+                }
+
                 // draw a frame
                 encoder.clear(&data.out, CLEAR_COLOR);
                 encoder.draw(&slice, &pso, &data);
                 encoder.flush(&mut device);
-                window_ctx.swap_buffers().unwrap();
+                gl_surface.swap_buffers(&gl_context).unwrap();
                 device.cleanup();
             }
             _ => (),

--- a/src/glutin_winit2.rs
+++ b/src/glutin_winit2.rs
@@ -1,0 +1,42 @@
+//! glutin-winit helpers (proposed <https://github.com/rust-windowing/glutin/pull/1545>)
+use glutin::surface::{SurfaceAttributes, SurfaceAttributesBuilder, WindowSurface};
+use raw_window_handle::HasRawWindowHandle;
+use std::num::NonZeroU32;
+use winit::window::Window;
+
+/// [`Window`] extensions for working with [`glutin`] surfaces.
+pub(crate) trait GlWindow {
+    /// Build the surface attributes suitable to create a window surface.
+    ///
+    /// Panics if either window inner dimension is zero.
+    fn build_surface_attributes(
+        &self,
+        builder: SurfaceAttributesBuilder<WindowSurface>,
+    ) -> SurfaceAttributes<WindowSurface>;
+}
+
+impl GlWindow for Window {
+    fn build_surface_attributes(
+        &self,
+        builder: SurfaceAttributesBuilder<WindowSurface>,
+    ) -> SurfaceAttributes<WindowSurface> {
+        let (w, h) = self
+            .inner_size()
+            .non_zero()
+            .expect("invalid zero inner size");
+        builder.build(self.raw_window_handle(), w, h)
+    }
+}
+
+/// [`winit::dpi::PhysicalSize<u32>`] non-zero extensions.
+pub(crate) trait NonZeroU32PhysicalSize {
+    /// Converts to non-zero `(width, height)`.
+    fn non_zero(self) -> Option<(NonZeroU32, NonZeroU32)>;
+}
+impl NonZeroU32PhysicalSize for winit::dpi::PhysicalSize<u32> {
+    fn non_zero(self) -> Option<(NonZeroU32, NonZeroU32)> {
+        let w = NonZeroU32::new(self.width)?;
+        let h = NonZeroU32::new(self.height)?;
+        Some((w, h))
+    }
+}


### PR DESCRIPTION
API to support _glutin_ `0.30`. See new docs & examples.

The crate version will no longer follow _glutin_ as now _winit_ releases may separately cause breaking changes.

## New usage
```rust
type ColorFormat = gfx::format::Srgba8;
type DepthFormat = gfx::format::DepthStencil;

let event_loop = winit::event_loop::EventLoop::new();
let window_builder = winit::window::WindowBuilder::new();

// Initialise winit window, glutin context & gfx views
let old_school_gfx_glutin_ext::Init {
    // winit window
    window,
    // glutin bits
    gl_config,
    gl_surface,
    gl_context,
    // gfx bits
    mut device,
    mut factory,
    mut color_view,
    mut depth_view,
    ..
} = old_school_gfx_glutin_ext::window_builder(&event_loop, window_builder)
    .build::<ColorFormat, DepthFormat>()?;

// Update gfx views, e.g. after a window resize
old_school_gfx_glutin_ext::resize_views(new_size, &mut color_view, &mut depth_view);
```

Resolves #4 