### PR TITLE
Update winit to `0.28`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased (v0.31.0)
+* Update _winit_ to `0.28`, _glutin-winit_ to `0.3`.
+
 # v0.30.2
 * Update _glutin-winit_ & reduce code.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,16 @@ gfx_device_gl = "0.16.2"
 glutin = { version = "0.30.3", default-features = false }
 glutin-winit = { version = "0.2.2", default-features = false }
 raw-window-handle = "0.5"
-winit = { version = "0.27", default-features = false }
+winit = { version = "0.28", default-features = false }
 
 [dev-dependencies]
 gfx = "0.18"
 # enable default features for examples
-winit = { version = "0.27", default-features = true }
+winit = { version = "0.28", default-features = true }
 
 [features]
 default = ["glutin-winit/default"]
+
+[patch.crates-io]
+glutin-winit = { git = "https://github.com/alexheretic/glutin", branch = "winit++" }
+glutin = { git = "https://github.com/alexheretic/glutin", branch = "winit++" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme="README.md"
 gfx_core = "0.9.2"
 gfx_device_gl = "0.16.2"
 glutin = { version = "0.30.3", default-features = false }
-glutin-winit = { version = "0.2.2", default-features = false }
+glutin-winit = { version = "0.3", default-features = false }
 raw-window-handle = "0.5"
 winit = { version = "0.28", default-features = false }
 
@@ -24,7 +24,3 @@ winit = { version = "0.28", default-features = true }
 
 [features]
 default = ["glutin-winit/default"]
-
-[patch.crates-io]
-glutin-winit = { git = "https://github.com/alexheretic/glutin", branch = "winit++" }
-glutin = { git = "https://github.com/alexheretic/glutin", branch = "winit++" }


### PR DESCRIPTION
Requires https://github.com/rust-windowing/glutin/pull/1560 & _glutin-winit_ release.