### PR TITLE
Allow incorrect glutin config depth == total bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+* Allow incorrect OS config depth_size = expected depth_size+stencil_size.
+  This works around an issue with macos software rendering.
+
 # v0.32.0
 * Update _winit_ to `0.29`, _glutin-winit_ to `0.4`, _glutin_ to `0.31`.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,7 @@ impl<T> Builder<'_, T> {
                             && color_bits == color_total_bits - alpha_bits
                             && c.alpha_size() == alpha_bits
                             && (c.depth_size() == depth_total_bits - stencil_bits
+                                // workaround to allow depth_size=32 & stencil_size=8 on macos software renderer
                                 || c.depth_size() == depth_total_bits)
                             && c.stencil_size() == stencil_bits
                     }));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,8 @@ impl<T> Builder<'_, T> {
                         (!srgb || c.srgb_capable())
                             && color_bits == color_total_bits - alpha_bits
                             && c.alpha_size() == alpha_bits
-                            && c.depth_size() == depth_total_bits - stencil_bits
+                            && (c.depth_size() == depth_total_bits - stencil_bits
+                                || c.depth_size() == depth_total_bits)
                             && c.stencil_size() == stencil_bits
                     }));
                 match best {


### PR DESCRIPTION
PR allows macos software renderer config depth incorrect config value to allow that to work.

See https://github.com/rust-windowing/glutin/issues/1659

Macos vm reports incorrect depth_size = 32, instead of 24.
```
// macos vm the only Config
config.depth_size() = 32
config.stencil_size() = 8
```